### PR TITLE
Add effect to lightstate

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ The __lightState__ object provides the following methods that can be used to bui
 - __xy(x, y)__ where x and y is from 0 to 1 in the Philips Color co-ordinate system
 - __rgb(red, green, blue)__ where red, green and blue are values from 0 to 255 - Not all colors can be created by the lights
 - __transition(seconds)__ this can be used with another setting to create a transition effect (like change brightness over 10 seconds)
+- __effect(value)__ this can be set to 'colorloop' or 'none'. The 'colorloop' rotates through all available hues at the current saturation level
 
 ### Creating Complex States
 The LightState object provides a simple way to build up JSON object to set multiple values on a Hue Light.

--- a/hue-api/lightstate.js
+++ b/hue-api/lightstate.js
@@ -105,6 +105,16 @@ State.prototype.rgb = function (r, g, b) {
     return this;
 };
 
+/**
+ * Adds the effect to the state
+ * @param value The effect value (either 'colorloop' or 'none'
+ * @return {State}
+ */
+State.prototype.effect = function (value) {
+    _combine(this, _getEffectState(value));
+    return this;
+};
+
 function _getXYState(x, y) {
     return {
         "xy": _getXYValue(x, y)
@@ -147,6 +157,12 @@ function _getOnState() {
 function _getOffState() {
     return {
         "on": false
+    };
+}
+
+function _getEffectState(value) {
+    return {
+        "effect": value
     };
 }
 


### PR DESCRIPTION
Hi.  I noticed when Philips released their API publicly that there's a colorloop effect available. (See http://developers.meethue.com/1_lightsapi.html#16_set_light_state)  This pull request is to get that into the node-hue-api.  
