### PR TITLE
setLightState group conditional should test for false rather than true

### DIFF
--- a/hue-api/api.js
+++ b/hue-api/api.js
@@ -352,7 +352,7 @@ HueApi.prototype.setLightState = function (id, stateValues, group) {
     }
 
     //helper function to validate group id - if group
-    if (group && _isGroupIdValid(id)) {
+    if (group && !_isGroupIdValid(id)) {
         throw new errors.ApiError("The group id '" + id + "' is not valid for this Hue Bridge.");
     }
 


### PR DESCRIPTION
Was running into the following error immediately after running `setLightState` on a newly-created group:

`Api Error: The group id '1' is not valid for this Hue Bridge.`

Looks like the conditional here should be testing for a false value rather than true.
