### PR TITLE
Fixed pure CT call.

### DIFF
--- a/hue-api/index.js
+++ b/hue-api/index.js
@@ -305,8 +305,8 @@ HueApi.prototype.setLightState = function (id, stateValues, cb) {
 
     if (!promise) {
         // We have not errored, so check if we need to convert an rgb value
-
-        if (stateValues.rgb) {
+        // This will be the case if rgb is no longer the method defined in lightstate.js
+        if (!isFunction(stateValues.rgb)) {
             promise = this.lightStatus(id)
                 .then(function(lightDetails) {
                     options.values.xy = rgb.convertRGBtoXY(stateValues.rgb, lightDetails);
@@ -932,4 +932,11 @@ function _isScheduleIdValid(id) {
     } else {
         return false;
     }
+}
+
+/** check that something is a function or not.
+ */
+function isFunction(functionToCheck) {
+ var getType = {};
+ return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
 }


### PR DESCRIPTION
When calling lightState with only a CT value, the rgb test would fail because the method rgb() had
never been called before, thus matching the condition erronously. The simple test fix settings the
color with `white(temp, bri)`.