### PR TITLE
Fix CORS issue when using with Electron

### DIFF
--- a/hue-api/httpPromise.js
+++ b/hue-api/httpPromise.js
@@ -4,12 +4,18 @@ var url = require("url")
   , util = require("util")
   , Q = require("q")
   , axios = require("axios")
+  , httpAdapter = require("axios/lib/adapters/http")
   , errors = require("./errors.js")
   , debug = /hue-api/.test(process.env.NODE_DEBUG)
   ;
 
+var defaultOptions = {
+  adapter: httpAdapter,
+};
+
 function buildOptions(command, parameters) {
   var options = {
+      adapter: httpAdapter,
       debug: debug,
       headers: {}
     },
@@ -152,7 +158,7 @@ module.exports.invoke = function (command, parameters) {
 };
 
 module.exports.simpleGet = function (uri) {
-  return wrapAxios(axios.get(uri))
+  return wrapAxios(axios.get(uri, defaultOptions))
       .then(requireStatusCode200)
       .then(function(result) {
           return result.data;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "xml2js": "~0.4",
     "q": "~1.4",
     "deep-extend": "~0.4.0",
-    "axios": "~0.8.1",
+    "axios": "~0.15.3",
     "traits": "~0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The axios client auto-switches the adapter to XHR even though the Node APIs are all available. This enforces the `http` adapter. This was necessary for me to get Electron to use the library.