### PR TITLE
Fix ListType#getValue

### DIFF
--- a/lib/parameters/ListType.js
+++ b/lib/parameters/ListType.js
@@ -45,7 +45,7 @@ module.exports = class ListType extends ParameterType {
 
     // Validate the values in the list
     const result = [];
-    for (var idx in listValues) {
+    for (var idx = 0; idx < length; idx++) {
       result.push(this.valueType.getValue(listValues[idx]));
     }
     return result;


### PR DESCRIPTION
Running on Node `v11.13.0`, the following call results in an error:

```javascript
api.setLightState(id, {
     on: true,
     xy: [0.1948, 0.5478]
})
```

Similar to:

```
    "stack": [
        "Error: Value, 'function(obj) {\r",
        "        var isObject = typeof obj === \"object\";\r",
        "        if (!isObject) {\r",
        "            return this.indexOf(obj);\r",
        "        }\r",
        "\r",
        "        for (var index = 0; index < this.length; index++) {\r",
        "            var valid = true;\r",
        "            var _obj = this[index];\r",
        "\r",
        "            for (var key in obj) {\r",
        "                var value = obj[key];\r",
        "                var _value = _obj[key];\r",
        "                if (value === _value) {\r",
        "                    continue;\r",
        "                }\r",
        "                valid = false;\r",
        "                break;\r",
        "            }\r",
        "\r",
        "            if (!valid) {\r",
        "                continue;\r",
        "            }\r",
        "\r",
        "            return index;\r",
        "        }\r",
        "\r",
        "        return -1;\r",
        "    }' is not within allowed limits: min=0 max=1",
        "    at FloatType.getValue (/Users/gcc/ripe-sputnik-device/node_modules/node-hue-api/lib/parameters/RangedNumberType.js:43:15)",
        "    at ListType.getValue (/Users/gcc/ripe-sputnik-device/node_modules/node-hue-api/lib/parameters/ListType.js:49:34)",
        "    at LightState._setStateValue (/Users/gcc/ripe-sputnik-device/node_modules/node-hue-api/lib/bridge-model/lightstate/States.js:87:53)",
        "    at Object.keys.forEach.key (/Users/gcc/ripe-sputnik-device/node_modules/node-hue-api/lib/bridge-model/lightstate/States.js:72:16)",
        "    at Array.forEach (<anonymous>)",
        "    at LightState.populate (/Users/gcc/ripe-sputnik-device/node_modules/node-hue-api/lib/bridge-model/lightstate/States.js:70:25)",
        "    at getStateForDevice (/Users/gcc/ripe-sputnik-device/node_modules/node-hue-api/lib/api/http/endpoints/lights.js:132:16)",
        "    at Object.buildLightStateBody [as _payloadFn] (/Users/gcc/ripe-sputnik-device/node_modules/node-hue-api/lib/api/http/endpoints/lights.js:106:19)",
        "    at ApiEndpoint.getRequest (/Users/gcc/ripe-sputnik-device/node_modules/node-hue-api/lib/api/http/endpoints/endpoint.js:101:26)",
        "    at Transport.execute (/Users/gcc/ripe-sputnik-device/node_modules/node-hue-api/lib/api/http/Transport.js:43:33)"
    ]
```

Where the problem is that the for-loop is iterating over `Array` properties, and not only its actual elements.