### PR TITLE
getLightByName going one level too deep

### DIFF
--- a/lib/api/Lights.js
+++ b/lib/api/Lights.js
@@ -25,7 +25,7 @@ module.exports = class Lights extends ApiDefinition {
 
   getLightByName(name) {
     return this.getAll().then(lights => {
-      return lights.lights.find(light => {
+      return lights.find(light => {
         return light.name === name;
       });
     });


### PR DESCRIPTION
The getLightByName method crashes since it goes one level too deep.