### PR TITLE
Disable HTTP proxy

### DIFF
--- a/lib/api/discovery/bridge-validation.js
+++ b/lib/api/discovery/bridge-validation.js
@@ -29,6 +29,7 @@ module.exports.getBridgeConfig = (bridge, timeout) => {
   return axios.request({
       method: 'get',
       url: `http://${ipAddress}/api/config`,
+      proxy: false,
       timeout: timeout | DATA_TIMEOUT,
       json: true,
     })

--- a/lib/api/discovery/nupnp.js
+++ b/lib/api/discovery/nupnp.js
@@ -9,6 +9,7 @@ module.exports.nupnp = function () {
 
   return axios.get('https://discovery.meethue.com', {
       headers: {accept: 'application/json'},
+      proxy: false,
       httpsAgent: caChain.getDiscoveryMeetHueHttpsAgent()
     })
     .catch(err => {

--- a/lib/api/http/LocalBootstrap.js
+++ b/lib/api/http/LocalBootstrap.js
@@ -61,7 +61,7 @@ module.exports = class LocalBootstrap {
       , baseUrl = self.baseUrl
     ;
 
-    return axios.get(`${baseUrl}/api/config`, {httpsAgent: new https.Agent({rejectUnauthorized: false})})
+    return axios.get(`${baseUrl}/api/config`, {proxy: false, httpsAgent: new https.Agent({rejectUnauthorized: false})})
       .then(res => {
         const bridgeId = res.data.bridgeid.toLowerCase();
 
@@ -99,7 +99,7 @@ module.exports = class LocalBootstrap {
           })
           .then(agent => {
             const apiBaseUrl = `${baseUrl}/api`
-              , transport = new Transport(username, axios.create({baseURL: apiBaseUrl, httpsAgent: agent}))
+              , transport = new Transport(username, axios.create({baseURL: apiBaseUrl, proxy: false, httpsAgent: agent}))
               , config = {
                 remote: false,
                 baseUrl: apiBaseUrl,

--- a/lib/api/http/RemoteApi.js
+++ b/lib/api/http/RemoteApi.js
@@ -268,6 +268,7 @@ module.exports = class RemoteApi {
         Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json'
       },
+      proxy: false,
       responseType: 'json'
     });
 

--- a/lib/api/http/RemoteBootstrap.js
+++ b/lib/api/http/RemoteBootstrap.js
@@ -115,6 +115,7 @@ module.exports = class RemoteBootstrap {
         headers: {
           Authorization: `Bearer ${self.remoteApi.accessToken}`
         },
+        proxy: false,
         timeout: getTimeout(timeout)
       }
       , transport = new Transport(username, axios.create(axiosConfig))

--- a/lib/api/http/endpoints/endpoint.js
+++ b/lib/api/http/endpoints/endpoint.js
@@ -97,6 +97,8 @@ class ApiEndpoint {
 
     data.url = replacePlaceholders(data.url, data.placeholders, parameters);
 
+    data.proxy = false;
+
     if (data._payloadFn) {
       let payload = data._payloadFn(parameters)
         , headers = data.headers


### PR DESCRIPTION
As shown in Bug #171, the HTTP proxy support is a) only completely broken, and b) makes no sense in this case. The proxy should not be used to contact a device on the local network. And the Hue bridge won't use a proxy to contact the Hue server, so neither should we, to be consistent.

This disables the proxy when making requests to the local bridge and the Hue server.

This fixes the code for me. Without this fix, everything simply fails when a proxy is configured for HTTPS.