### PR TITLE
Fix for connectWithTokens & connectWithCode

### DIFF
--- a/docs/remoteBootstrap.md
+++ b/docs/remoteBootstrap.md
@@ -64,7 +64,7 @@ time of writing.*
 
 
 ## connectWithCode
-The `connectWithCode(code, useername, timeout, deviceType, remoteBirdgeId)` function will perform the second step in the 
+The `connectWithCode(code, username, timeout, deviceType, remoteBridgeId)` function will perform the second step in the 
 OAuth authentication process following a user granting your application access to their Hue Bridge.  
 
 * `code`: The `authentication` code that you get from the Callback URL for your `Hue Remote Api Application`.
@@ -121,7 +121,7 @@ there is also a time limit on the refresh token.
 const v3 = require('node-hue-api').v3;
 
 const remoteBootstrap = v3.api.createRemote(clientId, clientSecret);
-remoteBootstrap.connectWithCode(code)
+remoteBootstrap.connectWithTokens(code)
   .then(api => {
     // Do something with the api like getting lights etc... 
   })


### PR DESCRIPTION
Hello Peter + all the dev's who've helped on this project!
This is such a great library, thanks for creating it.

### `connectWithTokens`
I've noticed a slight error in the example code for the `connectWithTokens` on the [remoteBootstrap.md](https://github.com/peter-murray/node-hue-api/blob/main/docs/remoteBootstrap.md) page


_Currently displayed as:_
```node.js
const v3 = require('node-hue-api').v3;
const remoteBootstrap = v3.api.createRemote(clientId, clientSecret);
remoteBootstrap.connectWithCode(code) //<<<ERROR IS HERE
  .then(api => {
    // Do something with the api like getting lights etc... 
  })
```

_Possible correction:_
```node.js
const v3 = require('node-hue-api').v3;
const remoteBootstrap = v3.api.createRemote(clientId, clientSecret);
remoteBootstrap.connectWithTokens(code) //<<<CORRECTION IS HERE
  .then(api => {
    // Do something with the api like getting lights etc... 
  })
```

### `connectWithCode`
Another small correction for this [remoteBootstrap.md](https://github.com/peter-murray/node-hue-api/blob/main/docs/remoteBootstrap.md) page is to correct the `connectWithCode` explanation text as `username` and `remoteBridgeId` are currently misspelt.
The first line current says:
**(incorrect)** "The `connectWithCode(code, useername, timeout, deviceType, remoteBirdgeId)` function will ..."
**(correct)** "The `connectWithCode(code, username, timeout, deviceType, remoteBridgeId)` function will ..."

Thanks again everyone!